### PR TITLE
Pass username as argument when calling tcmversion command

### DIFF
--- a/procrun.py
+++ b/procrun.py
@@ -67,14 +67,14 @@ class ProcRun(object):
 
     def run_async(self, user, arg_str=None, data=None, env={}, save=True):
         """ Run a the command asynchronously """
-        env['SLACK_USER'] = user
+        env['SLACK_USERNAME'] = user
         # Get the environment, or set the environment
         environ = dict(os.environ).copy()
         environ.update(env or {})
 
         # Create the array of arguments for the subprocess call
         cmd_args = [self.cmd] + self.expand_args(arg_str)
-        
+
         # Open the log file
         self.start_log(user, cmd_args)
         print(self.cmd)

--- a/procrun.py
+++ b/procrun.py
@@ -67,7 +67,10 @@ class ProcRun(object):
 
     def run_async(self, user, arg_str=None, data=None, env={}, save=True):
         """ Run a the command asynchronously """
+        
+        # Pass username as an environment variable to the scripts 
         env['SLACK_USERNAME'] = user
+
         # Get the environment, or set the environment
         environ = dict(os.environ).copy()
         environ.update(env or {})

--- a/procrun.py
+++ b/procrun.py
@@ -70,8 +70,11 @@ class ProcRun(object):
         # Get the environment, or set the environment
         environ = dict(os.environ).update(env or {})
 
+        if self.cmd == "/opt/errbot/cmds/tcmversion.sh":
+            cmd_args = [self.cmd, user] + self.expand_args(arg_str)
+        else:
+            cmd_args = [self.cmd] + self.expand_args(arg_str)
         # Create the array of arguments for the subprocess call
-        cmd_args = [self.cmd] + self.expand_args(arg_str)
 
         # Open the log file
         self.start_log(user, cmd_args)

--- a/procrun.py
+++ b/procrun.py
@@ -67,15 +67,14 @@ class ProcRun(object):
 
     def run_async(self, user, arg_str=None, data=None, env={}, save=True):
         """ Run a the command asynchronously """
+        env['SLACK_USER'] = user
         # Get the environment, or set the environment
-        environ = dict(os.environ).update(env or {})
+        environ = dict(os.environ).copy()
+        environ.update(env or {})
 
-        if self.cmd == "/opt/errbot/cmds/tcmversion.sh":
-            cmd_args = [self.cmd, user] + self.expand_args(arg_str)
-        else:
-            cmd_args = [self.cmd] + self.expand_args(arg_str)
         # Create the array of arguments for the subprocess call
-
+        cmd_args = [self.cmd] + self.expand_args(arg_str)
+        
         # Open the log file
         self.start_log(user, cmd_args)
         print(self.cmd)

--- a/shellexec.py
+++ b/shellexec.py
@@ -139,14 +139,15 @@ class ShellExec(BotPlugin):
 
         def new_method(self, msg, args, command_name=command_name):
             # Get who ran the command
-            user = msg.frm.nick
+            user = msg.frm.userid
+            username = msg.frm.nick
             # The full command to run
             os_cmd = join(self.command_path, command_name + ".sh")
             q = queue.Queue()
             proc = procrun.ProcRun(os_cmd, self.command_path, self.command_logs_path, q)
             print("args: " + str(args))
             t = threading.Thread(target=procrun.ProcRun.run_async,
-                args=(proc, user), kwargs={'arg_str':args})
+                args=(proc, username), kwargs={'arg_str':args})
             t.start()
             time.sleep(0.5)
             snippets = False

--- a/shellexec.py
+++ b/shellexec.py
@@ -139,7 +139,7 @@ class ShellExec(BotPlugin):
 
         def new_method(self, msg, args, command_name=command_name):
             # Get who ran the command
-            user = msg.frm.userid
+            user = msg.frm.nick
             # The full command to run
             os_cmd = join(self.command_path, command_name + ".sh")
             q = queue.Queue()

--- a/shellexec.py
+++ b/shellexec.py
@@ -140,6 +140,7 @@ class ShellExec(BotPlugin):
         def new_method(self, msg, args, command_name=command_name):
             # Get who ran the command
             user = msg.frm.userid
+            # Get the nick name of the user 
             username = msg.frm.nick
             # The full command to run
             os_cmd = join(self.command_path, command_name + ".sh")


### PR DESCRIPTION
> Changes
- Pass user's nick name instead of Userid to procrun
- Set the username in command's environment variable 